### PR TITLE
Add interactive CLI shell and Arch packaging recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,37 @@ applets with a dependable daemon + CLI combination that understands multiple
 controllers, audio routing, automation, and status bar integrations.
 
 ## Project Status
-This repository currently contains planning documentation only. Refer to the
-[architecture](docs/ARCHITECTURE.md) and [roadmap](docs/ROADMAP.md) documents for
-up-to-date implementation plans. The initial Go module and service code will be
-added once the bootstrap milestone is complete.
+This repository now includes the first pass at the Go module that will back the
+project. The `pearedd` daemon currently starts, waits for a cancellation signal,
+and shuts down cleanly—providing the scaffolding required for future Bluetooth
+management features. Refer to the [architecture](docs/ARCHITECTURE.md) and
+[roadmap](docs/ROADMAP.md) documents for the broader implementation plan.
+
+```bash
+go test ./...
+go run ./cmd/pearedd --log-level debug
+go run ./cmd/peared shell
+```
+
+The daemon exits when it receives `SIGINT`/`SIGTERM` or when the provided
+context is cancelled. The companion CLI now ships with an early interactive
+shell so you can validate that the binary launches and cleanly exits on your
+workstation. Type `help` inside the shell to see the available commands and use
+`exit` when you're finished testing.
+
+### Arch Linux packaging
+
+Early Arch Linux packaging bits live under `packaging/arch/PKGBUILD`. The
+PKGBUILD follows the usual `-git` convention so maintainers can build the latest
+commit without waiting for formal releases:
+
+```bash
+cd packaging/arch
+makepkg -si
+```
+
+The resulting package installs both the `pearedd` daemon and the `peared` CLI
+into `/usr/bin`.
 
 ## Configuration Hygiene
 Configuration templates and examples will always use placeholder adapter IDs and

--- a/cmd/peared/main.go
+++ b/cmd/peared/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/peared/peared/internal/cli"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "shell":
+		runShell(os.Args[2:])
+	case "help", "-h", "--help":
+		usage()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\n\n", os.Args[1])
+		usage()
+		os.Exit(2)
+	}
+}
+
+func runShell(args []string) {
+	fs := flag.NewFlagSet("shell", flag.ExitOnError)
+	logLevel := fs.String("log-level", "info", "Log level (debug, info, warn, error)")
+	prompt := fs.String("prompt", "peared> ", "Prompt to display for the interactive shell")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse flags: %v\n", err)
+		os.Exit(2)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseLevel(*logLevel)}))
+	logger.Info("starting interactive shell")
+	defer logger.Info("shell session ended")
+
+	shell := cli.NewShell(os.Stdin, os.Stdout, cli.WithPrompt(*prompt))
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if err := shell.Run(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			logger.Info("shell interrupted by context cancellation")
+			return
+		}
+		fmt.Fprintf(os.Stderr, "shell exited with error: %v\n", err)
+		os.Exit(1)
+	}
+
+	logger.Info("shell exited normally")
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Peared CLI\n\n")
+	fmt.Fprintf(os.Stderr, "Usage:\n")
+	fmt.Fprintf(os.Stderr, "  peared <command> [options]\n\n")
+	fmt.Fprintf(os.Stderr, "Available Commands:\n")
+	fmt.Fprintf(os.Stderr, "  shell   Start an interactive shell session\n")
+	fmt.Fprintf(os.Stderr, "  help    Show this message\n")
+}
+
+func parseLevel(level string) slog.Leveler {
+	switch strings.ToLower(level) {
+	case "debug":
+		lvl := slog.LevelDebug
+		return lvl
+	case "warn", "warning":
+		lvl := slog.LevelWarn
+		return lvl
+	case "error", "err":
+		lvl := slog.LevelError
+		return lvl
+	default:
+		lvl := slog.LevelInfo
+		return lvl
+	}
+}

--- a/cmd/pearedd/main.go
+++ b/cmd/pearedd/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/peared/peared/internal/daemon"
+)
+
+func main() {
+	var adapter string
+	var logLevel string
+
+	flag.StringVar(&adapter, "adapter", "", "Preferred adapter name or MAC address to prioritize")
+	flag.StringVar(&logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
+	flag.Parse()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseLevel(logLevel)}))
+
+	d, err := daemon.New(daemon.Options{
+		PreferredAdapter: adapter,
+		Logger:           logger,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to configure daemon: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	if err := d.Run(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "daemon exited with error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func parseLevel(level string) slog.Leveler {
+	switch strings.ToLower(level) {
+	case "debug":
+		lvl := slog.LevelDebug
+		return lvl
+	case "warn", "warning":
+		lvl := slog.LevelWarn
+		return lvl
+	case "error", "err":
+		lvl := slog.LevelError
+		return lvl
+	default:
+		lvl := slog.LevelInfo
+		return lvl
+	}
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,48 +2,127 @@
 
 This roadmap captures the initial backlog for delivering a reliable Bluetooth
 manager. Items are grouped by milestone to provide a guided development path.
+Each milestone now includes explicit deliverables, success criteria, and
+cross-cutting considerations so contributors can quickly understand what "done"
+looks like and how work items fit together.
 
 ## Milestone 0 – Project Bootstrap
+
+**Objective:** Set up the project so new contributors can clone the repository
+and run a minimal build/test loop without touching production systems.
+
+**Deliverables**
 - [ ] Publish repository metadata (README, architecture docs, contribution
-      guidelines).
-- [ ] Establish Go module layout and CI scaffolding.
-- [ ] Provide configuration templates with placeholder addresses and adapter IDs.
-- [ ] Adopt the GPL-3.0 license and document contributor guidance.
+      guidelines) with clear setup instructions for Arch and Debian developers.
+- [ ] Establish Go module layout and CI scaffolding (linting, unit tests, and
+      static analysis gates).
+- [ ] Provide configuration templates with placeholder addresses and adapter IDs
+      stored under `config/examples/`.
+- [ ] Adopt the GPL-3.0 license and document contributor guidance, including the
+      Developer Certificate of Origin (DCO) process.
+
+**Success Criteria**
+- [ ] `go test ./...` and `golangci-lint run` execute in CI on every pull
+      request.
+- [ ] A new developer can follow documented steps to build the project in under
+      15 minutes on a fresh workstation.
 
 ## Milestone 1 – Core Connectivity
-- [ ] Implement adapter discovery and selection across multiple controllers.
+
+**Objective:** Provide a resilient daemon capable of discovering adapters and
+maintaining device connectivity across restarts or system hiccups.
+
+**Deliverables**
+- [ ] Implement adapter discovery and selection across multiple controllers,
+      exposing the active adapter through the daemon API.
 - [ ] Surface radio block state (via BlueZ or rfkill) with clear error messaging
-      and controlled unblocking.
+      and controlled unblocking, including audit logs of unblock attempts.
 - [ ] Provide reset workflows for bluetoothd (systemd), kernel modules, and
-      BlueZ service restarts with retry semantics.
-- [ ] Implement device connect/disconnect/trust flows with retry policies.
+      BlueZ service restarts with retry semantics and exponential backoff.
+- [ ] Implement device connect/disconnect/trust flows with retry policies and
+      persistence of known devices.
 - [ ] Ensure PipeWire sink/source switching when connecting audio devices and
-      fall back to ALSA where necessary.
+      fall back to ALSA where necessary, logging the chosen route.
+
+**Success Criteria**
+- [ ] Automated integration tests simulate adapter removal/insertion and verify
+      stable reconnection.
+- [ ] CLI status output reflects accurate adapter and device state within
+      1 second of change events.
 
 ## Milestone 2 – User Interface Layer
+
+**Objective:** Ship the first user-facing tools that interact with the daemon
+and surface state changes in a desktop environment.
+
+**Deliverables**
 - [ ] Deliver a CLI client for the daemon (connect, disconnect, scan, status,
-      reset, forget).
-- [ ] Integrate desktop notifications via D-Bus (e.g., `notify-send`).
+      reset, forget) with contextual help output.
+- [ ] Integrate desktop notifications via D-Bus (e.g., `notify-send`) with
+      user-configurable verbosity levels.
 - [ ] Ship optional status bar outputs compatible with Waybar, Polybar, and
       similar projects without depending on any single compositor.
 
+**Success Criteria**
+- [ ] CLI commands return structured exit codes and machine-readable output
+      (JSON) when requested.
+- [ ] Notification system respects quiet hours and suppresses duplicate alerts
+      during rapid reconnect attempts.
+
 ## Milestone 3 – Automation & Rules
+
+**Objective:** Allow the daemon to respond to context and user-defined policies
+without manual intervention.
+
+**Deliverables**
 - [ ] Create a rule engine for time-based, manual trigger, and proximity-based
-      actions.
-- [ ] Support per-device priorities and automatic reconnection policies.
-- [ ] Offer hooks for custom scripts upon connection/disconnection events.
+      actions with YAML/TOML configuration support.
+- [ ] Support per-device priorities and automatic reconnection policies that
+      interact with multiple adapters.
+- [ ] Offer hooks for custom scripts upon connection/disconnection events with
+      sandboxing guidance.
+
+**Success Criteria**
+- [ ] Rule evaluations are observable via logs and optionally metrics so users
+      can audit automation behavior.
+- [ ] Integration tests cover at least one scenario for each trigger type.
 
 ## Milestone 4 – Advanced Audio Controls
-- [ ] Device-specific volume presets and smoothing curves.
-- [ ] Microphone/monitor selection with failover detection.
+
+**Objective:** Provide audio experiences tailored to device capabilities while
+handling edge cases that typically require manual intervention.
+
+**Deliverables**
+- [ ] Device-specific volume presets and smoothing curves persisted per profile.
+- [ ] Microphone/monitor selection with failover detection and user prompts when
+      intervention is required.
 - [ ] PipeWire graph inspection to ensure the selected profile matches device
-      capabilities (HSP/HFP/A2DP).
+      capabilities (HSP/HFP/A2DP) with fallback heuristics when mismatches occur.
+
+**Success Criteria**
+- [ ] Automated checks validate that profile switching restores the previous
+      volume curves after reconnect.
+- [ ] User feedback loop (CLI or notification) confirms when the system falls
+      back to ALSA and why.
 
 ## Milestone 5 – Extensibility & Distribution
-- [ ] Document an extension API for community plugins.
+
+**Objective:** Ensure the project can be extended by the community and installed
+across popular Linux distributions with minimal friction.
+
+**Deliverables**
+- [ ] Document an extension API for community plugins with versioning and
+      stability guarantees.
 - [ ] Package for Arch Linux (AUR), Debian packages, Flatpak, and generic
-      tarballs.
-- [ ] Provide migration tooling for existing bluetoothctl scripts.
+      tarballs with reproducible build instructions.
+- [ ] Provide migration tooling for existing bluetoothctl scripts, including
+      documentation on equivalent commands.
+
+**Success Criteria**
+- [ ] Binary releases are produced automatically on tagged commits and pass
+      smoke tests in containerized environments.
+- [ ] At least two community extensions are validated against the API contract
+      before stabilizing it.
 
 ## Non-Goals (for now)
 - Managing mobile platforms or Windows/macOS.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module github.com/peared/peared
+
+go 1.22
+

--- a/internal/cli/shell.go
+++ b/internal/cli/shell.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync/atomic"
+)
+
+// Shell provides a minimal interactive prompt for controlling the daemon. It is
+// intentionally small for now so we can iterate quickly while we flesh out the
+// underlying control plane.
+type Shell struct {
+	reader *bufio.Reader
+	writer io.Writer
+	prompt string
+
+	closed atomic.Bool
+}
+
+// ShellOption allows customization of the shell when constructed.
+type ShellOption func(*Shell)
+
+// WithPrompt customizes the shell prompt string.
+func WithPrompt(prompt string) ShellOption {
+	return func(s *Shell) {
+		s.prompt = prompt
+	}
+}
+
+// NewShell creates a Shell instance that reads commands from r and writes
+// output to w. Callers may provide additional options to tweak defaults.
+func NewShell(r io.Reader, w io.Writer, opts ...ShellOption) *Shell {
+	shell := &Shell{
+		reader: bufio.NewReader(r),
+		writer: w,
+		prompt: "peared> ",
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(shell)
+		}
+	}
+
+	return shell
+}
+
+// Run executes the interactive loop until the user exits or the context is
+// cancelled. Unknown commands result in a helpful message so early adopters can
+// understand the current surface area.
+func (s *Shell) Run(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("nil context passed to Shell.Run")
+	}
+
+	if s.closed.Load() {
+		return errors.New("shell already closed")
+	}
+
+	fmt.Fprintf(s.writer, "Welcome to the Peared shell! Type 'help' to see available commands.\n")
+
+	type input struct {
+		line string
+		err  error
+	}
+
+	inputCh := make(chan input, 1)
+	go func() {
+		defer close(inputCh)
+		for {
+			line, err := s.reader.ReadString('\n')
+			select {
+			case <-ctx.Done():
+				return
+			case inputCh <- input{line: line, err: err}:
+			}
+
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	for {
+		fmt.Fprint(s.writer, s.prompt)
+
+		select {
+		case <-ctx.Done():
+			s.closed.Store(true)
+			if cause := context.Cause(ctx); cause != nil {
+				return cause
+			}
+			return context.Canceled
+		case in, ok := <-inputCh:
+			if !ok {
+				fmt.Fprintln(s.writer)
+				s.closed.Store(true)
+				return nil
+			}
+
+			if in.err != nil {
+				if errors.Is(in.err, io.EOF) {
+					fmt.Fprintln(s.writer)
+					s.closed.Store(true)
+					return nil
+				}
+				s.closed.Store(true)
+				return in.err
+			}
+
+			cmd := strings.TrimSpace(in.line)
+			switch strings.ToLower(cmd) {
+			case "", "#":
+				continue
+			case "exit", "quit":
+				fmt.Fprintln(s.writer, "Goodbye!")
+				s.closed.Store(true)
+				return nil
+			case "help":
+				s.writeHelp()
+			default:
+				fmt.Fprintf(s.writer, "Unknown command: %s\n", cmd)
+			}
+		}
+	}
+}
+
+func (s *Shell) writeHelp() {
+	fmt.Fprintf(s.writer, "Available commands:\n")
+	fmt.Fprintf(s.writer, "  help  - show this message\n")
+	fmt.Fprintf(s.writer, "  exit  - leave the shell\n")
+	fmt.Fprintf(s.writer, "  quit  - alias for exit\n")
+}

--- a/internal/cli/shell_test.go
+++ b/internal/cli/shell_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestShellRunExit(t *testing.T) {
+	input := strings.NewReader("help\nexit\n")
+	var output bytes.Buffer
+
+	shell := NewShell(input, &output)
+	if err := shell.Run(context.Background()); err != nil {
+		t.Fatalf("shell.Run returned error: %v", err)
+	}
+
+	out := output.String()
+	if !strings.Contains(out, "Welcome to the Peared shell") {
+		t.Fatalf("expected welcome message, got: %q", out)
+	}
+	if !strings.Contains(out, "Available commands") {
+		t.Fatalf("expected help output, got: %q", out)
+	}
+	if !strings.Contains(out, "Goodbye!") {
+		t.Fatalf("expected goodbye message, got: %q", out)
+	}
+}
+
+func TestShellRunUnknownCommand(t *testing.T) {
+	input := strings.NewReader("foo\nexit\n")
+	var output bytes.Buffer
+
+	shell := NewShell(input, &output)
+	if err := shell.Run(context.Background()); err != nil {
+		t.Fatalf("shell.Run returned error: %v", err)
+	}
+
+	out := output.String()
+	if !strings.Contains(out, "Unknown command: foo") {
+		t.Fatalf("expected unknown command message, got: %q", out)
+	}
+}
+
+func TestShellRunContextCancel(t *testing.T) {
+	r, w := io.Pipe()
+	var output bytes.Buffer
+
+	shell := NewShell(r, &output)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error)
+	go func() {
+		done <- shell.Run(ctx)
+	}()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("shell did not return after context cancellation")
+	}
+
+	_ = w.Close()
+}
+
+func TestShellRunTwice(t *testing.T) {
+	input := strings.NewReader("exit\n")
+	var output bytes.Buffer
+
+	shell := NewShell(input, &output)
+	if err := shell.Run(context.Background()); err != nil {
+		t.Fatalf("first run returned error: %v", err)
+	}
+
+	if err := shell.Run(context.Background()); err == nil {
+		t.Fatal("expected error on second run but got nil")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+)
+
+// Options configures the behavior of the daemon when constructed.
+type Options struct {
+	// PreferredAdapter is the adapter identifier the daemon should try to use
+	// first. Leaving it empty defers to automatic selection.
+	PreferredAdapter string
+
+	// Logger allows callers to provide a slog.Logger configured with project
+	// defaults. A sensible default logger is used when nil.
+	Logger *slog.Logger
+}
+
+// Daemon represents the long-running coordination process that will manage
+// Bluetooth adapters and connections.
+type Daemon struct {
+	preferredAdapter string
+	log              *slog.Logger
+}
+
+// New constructs a Daemon from the provided options.
+func New(opts Options) (*Daemon, error) {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+		if logger == nil {
+			logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
+		}
+	}
+
+	return &Daemon{
+		preferredAdapter: opts.PreferredAdapter,
+		log:              logger,
+	}, nil
+}
+
+// Run starts the daemon loop and blocks until the context is cancelled or an
+// unrecoverable error occurs.
+func (d *Daemon) Run(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("nil context passed to Run")
+	}
+
+	d.log.Info("daemon started", "preferred_adapter", d.preferredAdapter)
+	<-ctx.Done()
+
+	if err := context.Cause(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		d.log.Error("daemon exiting due to context error", "error", err)
+		return err
+	}
+
+	d.log.Info("daemon stopped")
+	return nil
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1,0 +1,105 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestNewUsesDefaultLogger(t *testing.T) {
+	d, err := New(Options{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if d.log == nil {
+		t.Fatalf("expected daemon to configure a logger")
+	}
+}
+
+func TestRunRespectsCancellation(t *testing.T) {
+	d, err := New(Options{Logger: slog.New(slog.NewTextHandler(testWriter{t}, nil))})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := d.Run(ctx); err != nil {
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected cancellation error, got %v", err)
+		}
+	}
+}
+
+func TestRunPropagatesContextError(t *testing.T) {
+	d, err := New(Options{Logger: slog.New(slog.NewTextHandler(testWriter{t}, nil))})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(errors.New("boom"))
+
+	err = d.Run(ctx)
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("expected boom error, got %v", err)
+	}
+}
+
+// testWriter implements io.Writer using testing.T logging so that slog output
+// is visible when tests run with -v.
+type testWriter struct {
+	t *testing.T
+}
+
+func (w testWriter) Write(p []byte) (int, error) {
+	w.t.Helper()
+	w.t.Logf("daemon log: %s", string(p))
+	return len(p), nil
+}
+
+func TestRunNilContext(t *testing.T) {
+	d, err := New(Options{})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if err := d.Run(nil); err == nil {
+		t.Fatalf("expected error when context is nil")
+	}
+}
+
+func TestRunBlocksUntilCancelled(t *testing.T) {
+	d, err := New(Options{Logger: slog.New(slog.NewTextHandler(testWriter{t}, nil))})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		if err := d.Run(ctx); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("daemon returned before cancellation")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("daemon did not return after cancellation")
+	}
+}

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Peared Developers <dev@peared.sh>
+
+pkgname=peared-git
+pkgver=0
+pkgrel=1
+pkgdesc="Bluetooth management toolkit daemon and CLI"
+arch=('x86_64' 'aarch64')
+url="https://github.com/peared/peared"
+license=('GPL3')
+depends=('bluez' 'dbus')
+makedepends=('go' 'git')
+provides=('peared')
+conflicts=('peared')
+source=("git+https://github.com/peared/peared.git")
+sha256sums=('SKIP')
+
+pkgver() {
+        cd "${srcdir}/peared"
+        printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+        cd "${srcdir}/peared"
+        git submodule update --init
+}
+
+build() {
+        cd "${srcdir}/peared"
+        export CGO_ENABLED=0
+        go build -o build/pearedd ./cmd/pearedd
+        go build -o build/peared ./cmd/peared
+}
+
+check() {
+        cd "${srcdir}/peared"
+        go test ./...
+}
+
+package() {
+        cd "${srcdir}/peared"
+        install -Dm755 build/pearedd "${pkgdir}/usr/bin/pearedd"
+        install -Dm755 build/peared "${pkgdir}/usr/bin/peared"
+        install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+        install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}


### PR DESCRIPTION
## Summary
- add a `peared` CLI entrypoint that exposes an interactive shell for early testing
- implement a reusable shell package with coverage for help, exit, and cancellation semantics
- introduce an Arch Linux `PKGBUILD` and document makepkg usage in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e33ac440f0832bb3f7f8a537a7f56f