### PR TITLE
Add configuration loader and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.58
+          args: --timeout=5m

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Peared
+
+Thank you for your interest in improving Peared! The project is still early in
+its roadmap, so contributions that improve tooling, documentation, or core
+functionality are especially appreciated.
+
+## Getting Started
+- Install Go 1.22 or newer.
+- Clone the repository and run `go test ./...` to verify your environment.
+- Review the [architecture](docs/ARCHITECTURE.md) and [roadmap](docs/ROADMAP.md)
+  documents to understand the current priorities.
+
+## Developer Certificate of Origin (DCO)
+
+Peared uses the [Developer Certificate of Origin](https://developercertificate.org)
+for all contributions. When opening a pull request, make sure each commit is
+signed off by including a `Signed-off-by` trailer:
+
+```
+Signed-off-by: Your Name <you@example.com>
+```
+
+You can add this automatically with:
+
+```
+git commit -s
+```
+
+Commits without a valid sign-off will need to be amended before they can be
+merged.
+
+## Testing & CI
+
+- Run `go test ./...` before submitting a change.
+- Keep `golangci-lint` happy once the linting workflow lands; lint clean merges
+  faster.
+- Include unit tests whenever practical so we can confidently evolve the codebase.
+
+## Communication
+
+- File issues for bugs or feature requests.
+- Draft pull requests are welcome for early feedback.
+- Be kind and respectful when interacting with other contributors—we're all here
+  to build a better Bluetooth experience.

--- a/README.md
+++ b/README.md
@@ -16,14 +16,20 @@ management features. Refer to the [architecture](docs/ARCHITECTURE.md) and
 ```bash
 go test ./...
 go run ./cmd/pearedd --log-level debug
+go run ./cmd/pearedd --config /path/to/config.yaml
 go run ./cmd/peared shell
 ```
 
 The daemon exits when it receives `SIGINT`/`SIGTERM` or when the provided
-context is cancelled. The companion CLI now ships with an early interactive
-shell so you can validate that the binary launches and cleanly exits on your
-workstation. Type `help` inside the shell to see the available commands and use
-`exit` when you're finished testing.
+context is cancelled. It now consumes configuration from the standard XDG
+location (`$XDG_CONFIG_HOME/peared/config.yaml`) or a path supplied via
+`--config`. The companion CLI ships with an early interactive shell so you can
+validate that the binary launches and cleanly exits on your workstation. Type
+`help` inside the shell to see the available commands and use `exit` when you're
+finished testing.
+
+Copy `config/examples/minimal.yaml` into your configuration directory to get
+started with placeholder values for preferred adapters.
 
 ### Arch Linux packaging
 

--- a/cmd/pearedd/main.go
+++ b/cmd/pearedd/main.go
@@ -11,22 +11,37 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/peared/peared/internal/config"
 	"github.com/peared/peared/internal/daemon"
 )
 
 func main() {
 	var adapter string
+	var configPath string
 	var logLevel string
 
 	flag.StringVar(&adapter, "adapter", "", "Preferred adapter name or MAC address to prioritize")
+	flag.StringVar(&configPath, "config", "", "Path to configuration file (defaults to XDG config directory)")
 	flag.StringVar(&logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	flag.Parse()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseLevel(logLevel)}))
 
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	if adapter == "" {
+		adapter = cfg.Daemon.PreferredAdapter
+	}
+
 	d, err := daemon.New(daemon.Options{
 		PreferredAdapter: adapter,
 		Logger:           logger,
+		ConfigSource:     cfg.Source,
+		ConfigLoaded:     cfg.Loaded,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to configure daemon: %v\n", err)

--- a/config/examples/minimal.yaml
+++ b/config/examples/minimal.yaml
@@ -1,0 +1,9 @@
+# Example Peared configuration with placeholder values.
+# Copy this file to $XDG_CONFIG_HOME/peared/config.yaml and edit as needed.
+
+daemon:
+  # Choose a preferred adapter to prioritize when multiple controllers are present.
+  # Replace the placeholder with an adapter address or alias returned by bluetoothctl.
+  preferred_adapter: "AA:BB:CC:DD:EE:FF"
+
+# Future sections (devices, automation, audio, etc.) will be added as the roadmap progresses.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,9 +16,9 @@ and run a minimal build/test loop without touching production systems.
       guidelines) with clear setup instructions for Arch and Debian developers.
 - [ ] Establish Go module layout and CI scaffolding (linting, unit tests, and
       static analysis gates).
-- [ ] Provide configuration templates with placeholder addresses and adapter IDs
+- [x] Provide configuration templates with placeholder addresses and adapter IDs
       stored under `config/examples/`.
-- [ ] Adopt the GPL-3.0 license and document contributor guidance, including the
+- [x] Adopt the GPL-3.0 license and document contributor guidance, including the
       Developer Certificate of Origin (DCO) process.
 
 **Success Criteria**

--- a/go.mod
+++ b/go.mod
@@ -2,3 +2,4 @@ module github.com/peared/peared
 
 go 1.22
 
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,72 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the on-disk configuration for the daemon and ancillary tools.
+type Config struct {
+	// Source tracks the path used to load the configuration. It is informational only.
+	Source string `yaml:"-"`
+
+	// Loaded reports whether the configuration file existed and was decoded.
+	Loaded bool `yaml:"-"`
+
+	Daemon DaemonConfig `yaml:"daemon"`
+}
+
+// DaemonConfig holds daemon-specific options from the configuration file.
+type DaemonConfig struct {
+	PreferredAdapter string `yaml:"preferred_adapter"`
+}
+
+// ResolvePath determines the configuration path to use. Explicit paths are honored first,
+// followed by the PEARED_CONFIG environment variable, and finally the default XDG location.
+func ResolvePath(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+
+	if env := os.Getenv("PEARED_CONFIG"); env != "" {
+		return env, nil
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve config dir: %w", err)
+	}
+
+	return filepath.Join(configDir, "peared", "config.yaml"), nil
+}
+
+// Load reads configuration from disk, returning default values if the file does not exist.
+func Load(path string) (*Config, error) {
+	resolved, err := ResolvePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &Config{Source: resolved}
+
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("read config %q: %w", resolved, err)
+	}
+
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("decode config %q: %w", resolved, err)
+	}
+
+	cfg.Source = resolved
+	cfg.Loaded = true
+	return cfg, nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolvePath(t *testing.T) {
+	t.Setenv("PEARED_CONFIG", "")
+
+	explicit, err := ResolvePath("/tmp/peared.yaml")
+	if err != nil {
+		t.Fatalf("ResolvePath explicit: %v", err)
+	}
+	if explicit != "/tmp/peared.yaml" {
+		t.Fatalf("unexpected explicit path: %q", explicit)
+	}
+
+	t.Setenv("PEARED_CONFIG", "/custom/path.yaml")
+	resolved, err := ResolvePath("")
+	if err != nil {
+		t.Fatalf("ResolvePath env: %v", err)
+	}
+	if resolved != "/custom/path.yaml" {
+		t.Fatalf("unexpected env path: %q", resolved)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	t.Setenv("PEARED_CONFIG", "")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load missing file: %v", err)
+	}
+	if cfg.Source != path {
+		t.Fatalf("expected source %q, got %q", path, cfg.Source)
+	}
+	if cfg.Loaded {
+		t.Fatalf("expected Loaded to be false")
+	}
+	if cfg.Daemon.PreferredAdapter != "" {
+		t.Fatalf("expected zero PreferredAdapter, got %q", cfg.Daemon.PreferredAdapter)
+	}
+}
+
+func TestLoadExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "daemon:\n  preferred_adapter: test-adapter\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load existing file: %v", err)
+	}
+	if !cfg.Loaded {
+		t.Fatalf("expected Loaded to be true")
+	}
+	if cfg.Daemon.PreferredAdapter != "test-adapter" {
+		t.Fatalf("unexpected PreferredAdapter: %q", cfg.Daemon.PreferredAdapter)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -16,6 +16,13 @@ type Options struct {
 	// Logger allows callers to provide a slog.Logger configured with project
 	// defaults. A sensible default logger is used when nil.
 	Logger *slog.Logger
+
+	// ConfigSource is the path used to load configuration. It is surfaced in logs
+	// to help troubleshoot configuration resolution.
+	ConfigSource string
+
+	// ConfigLoaded indicates whether a configuration file was found on disk.
+	ConfigLoaded bool
 }
 
 // Daemon represents the long-running coordination process that will manage
@@ -23,6 +30,8 @@ type Options struct {
 type Daemon struct {
 	preferredAdapter string
 	log              *slog.Logger
+	configSource     string
+	configLoaded     bool
 }
 
 // New constructs a Daemon from the provided options.
@@ -38,6 +47,8 @@ func New(opts Options) (*Daemon, error) {
 	return &Daemon{
 		preferredAdapter: opts.PreferredAdapter,
 		log:              logger,
+		configSource:     opts.ConfigSource,
+		configLoaded:     opts.ConfigLoaded,
 	}, nil
 }
 
@@ -48,7 +59,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return errors.New("nil context passed to Run")
 	}
 
-	d.log.Info("daemon started", "preferred_adapter", d.preferredAdapter)
+	d.log.Info("daemon started", "preferred_adapter", d.preferredAdapter, "config_source", d.configSource, "config_loaded", d.configLoaded)
 	<-ctx.Done()
 
 	if err := context.Cause(ctx); err != nil && !errors.Is(err, context.Canceled) {


### PR DESCRIPTION
## Summary
- add a configuration loader package and integrate it with the pearedd daemon
- document contributor guidance, ship an example config template, and mark the roadmap items as complete
- enable GitHub Actions CI to run go test and golangci-lint on every push and pull request

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e33e75ba70832ba1e07662760751b0