### PR TITLE
Update Arch PKGBUILD to use accessible GitHub mirror

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -5,13 +5,13 @@ pkgver=0
 pkgrel=1
 pkgdesc="Bluetooth management toolkit daemon and CLI"
 arch=('x86_64' 'aarch64')
-url="https://github.com/peared/peared"
+url="https://github.com/ttpears/peared"
 license=('GPL3')
 depends=('bluez' 'dbus')
 makedepends=('go' 'git')
 provides=('peared')
 conflicts=('peared')
-source=("git+https://github.com/peared/peared.git")
+source=("git+https://github.com/ttpears/peared.git")
 sha256sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
## Summary
- point the Arch PKGBUILD to the public ttpears/peared repository so cloning no longer prompts for credentials

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e33f49fe24832b9cb08f389e9d767c