### PR TITLE
Add adapter selection to daemon

### DIFF
--- a/internal/daemon/adapter.go
+++ b/internal/daemon/adapter.go
@@ -1,0 +1,63 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+)
+
+// Adapter represents a Bluetooth controller the daemon can manage. The fields
+// focus on identifiers that are stable across restarts so selection logic can
+// favour consistent hardware when multiple adapters are present.
+type Adapter struct {
+	// ID is a stable identifier for the adapter (e.g. D-Bus object path or
+	// kernel name like hci0).
+	ID string
+
+	// Address is the MAC address associated with the adapter.
+	Address string
+
+	// Alias is a human-friendly label surfaced by BlueZ.
+	Alias string
+
+	// Powered indicates whether the adapter radio is currently powered on.
+	Powered bool
+}
+
+// Matches returns true when the adapter corresponds to the provided identifier.
+// It performs case-insensitive comparisons across the adapter's ID, address,
+// and alias so callers can provide whichever value they have available.
+func (a Adapter) Matches(identifier string) bool {
+	id := strings.TrimSpace(identifier)
+	if id == "" {
+		return false
+	}
+
+	if strings.EqualFold(a.ID, id) {
+		return true
+	}
+
+	if strings.EqualFold(a.Address, id) {
+		return true
+	}
+
+	if strings.EqualFold(a.Alias, id) {
+		return true
+	}
+
+	return false
+}
+
+// AdapterProvider knows how to discover adapters that are currently available
+// on the system.
+type AdapterProvider interface {
+	ListAdapters(ctx context.Context) ([]Adapter, error)
+}
+
+// AdapterProviderFunc adapts a function to the AdapterProvider interface so
+// tests can easily stub discovery logic.
+type AdapterProviderFunc func(ctx context.Context) ([]Adapter, error)
+
+// ListAdapters implements AdapterProvider.
+func (f AdapterProviderFunc) ListAdapters(ctx context.Context) ([]Adapter, error) {
+	return f(ctx)
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -19,7 +19,12 @@ func TestNewUsesDefaultLogger(t *testing.T) {
 }
 
 func TestRunRespectsCancellation(t *testing.T) {
-	d, err := New(Options{Logger: slog.New(slog.NewTextHandler(testWriter{t}, nil))})
+	d, err := New(Options{
+		Logger: slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		AdapterProvider: AdapterProviderFunc(func(context.Context) ([]Adapter, error) {
+			return []Adapter{{ID: "test"}}, nil
+		}),
+	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -35,7 +40,12 @@ func TestRunRespectsCancellation(t *testing.T) {
 }
 
 func TestRunPropagatesContextError(t *testing.T) {
-	d, err := New(Options{Logger: slog.New(slog.NewTextHandler(testWriter{t}, nil))})
+	d, err := New(Options{
+		Logger: slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		AdapterProvider: AdapterProviderFunc(func(context.Context) ([]Adapter, error) {
+			return []Adapter{{ID: "test"}}, nil
+		}),
+	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -62,7 +72,9 @@ func (w testWriter) Write(p []byte) (int, error) {
 }
 
 func TestRunNilContext(t *testing.T) {
-	d, err := New(Options{})
+	d, err := New(Options{AdapterProvider: AdapterProviderFunc(func(context.Context) ([]Adapter, error) {
+		return []Adapter{{ID: "test"}}, nil
+	})})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -73,7 +85,12 @@ func TestRunNilContext(t *testing.T) {
 }
 
 func TestRunBlocksUntilCancelled(t *testing.T) {
-	d, err := New(Options{Logger: slog.New(slog.NewTextHandler(testWriter{t}, nil))})
+	d, err := New(Options{
+		Logger: slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		AdapterProvider: AdapterProviderFunc(func(context.Context) ([]Adapter, error) {
+			return []Adapter{{ID: "test"}}, nil
+		}),
+	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -102,4 +119,93 @@ func TestRunBlocksUntilCancelled(t *testing.T) {
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("daemon did not return after cancellation")
 	}
+}
+
+func TestRunSelectsPreferredAdapter(t *testing.T) {
+	adapters := []Adapter{{ID: "hci0", Address: "AA:BB"}, {ID: "hci1", Address: "CC:DD"}}
+	provider := AdapterProviderFunc(func(context.Context) ([]Adapter, error) {
+		return adapters, nil
+	})
+
+	d, err := New(Options{
+		Logger:           slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		AdapterProvider:  provider,
+		PreferredAdapter: "hci1",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		if err := d.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("unexpected error: %v", err)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-time.After(10 * time.Millisecond):
+	case <-done:
+		t.Fatal("daemon exited early")
+	}
+
+	adapter, ok := d.ActiveAdapter()
+	if !ok {
+		t.Fatal("expected active adapter")
+	}
+
+	if adapter.ID != "hci1" {
+		t.Fatalf("expected preferred adapter hci1, got %s", adapter.ID)
+	}
+
+	cancel()
+	<-done
+}
+
+func TestRunFallsBackToFirstAdapter(t *testing.T) {
+	adapters := []Adapter{{ID: "hci0", Address: "AA:BB"}, {ID: "hci1", Address: "CC:DD"}}
+	provider := AdapterProviderFunc(func(context.Context) ([]Adapter, error) {
+		return adapters, nil
+	})
+
+	d, err := New(Options{
+		Logger:          slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		AdapterProvider: provider,
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		if err := d.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("unexpected error: %v", err)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-time.After(10 * time.Millisecond):
+	case <-done:
+		t.Fatal("daemon exited early")
+	}
+
+	adapter, ok := d.ActiveAdapter()
+	if !ok {
+		t.Fatal("expected active adapter")
+	}
+
+	if adapter.ID != "hci0" {
+		t.Fatalf("expected fallback adapter hci0, got %s", adapter.ID)
+	}
+
+	cancel()
+	<-done
 }


### PR DESCRIPTION
## Summary
- add adapter model and provider abstraction to the daemon package
- select an active adapter during startup and expose it via ActiveAdapter
- expand daemon tests to cover adapter discovery and selection behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e34121911c832b9d5abc27e42e64b9