### PR TITLE
Add CLI commands for Bluetooth device management

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ go run ./cmd/pearedd --log-level debug
 go run ./cmd/pearedd --config /path/to/config.yaml
 go run ./cmd/peared shell
 go run ./cmd/peared adapters list
+go run ./cmd/peared devices scan
+go run ./cmd/peared devices pair AA:BB:CC:DD:EE:FF
 ```
 
 The daemon exits when it receives `SIGINT`/`SIGTERM` or when the provided
@@ -37,6 +39,13 @@ sysfs hierarchy usually works without additional setup, but some distributions
 restrict access to `/sys/class/bluetooth`. If you encounter a permission error,
 run the command with elevated privileges or add your user to the `bluetooth`
 group so discovery can proceed.
+
+The new `peared devices` commands wrap `bluetoothctl` to scan, pair, connect,
+and disconnect hardware without dropping into the interactive shell. These
+operations often require elevated permissions; the CLI automatically attempts
+to escalate via `sudo` when not executed as root. Ensure your user can run
+`sudo bluetoothctl` or invoke the command as root if pairing fails with a
+permission error.
 
 Copy `config/examples/minimal.yaml` into your configuration directory to get
 started. You can optionally set `preferred_adapter` in the file using the values

--- a/internal/bluetoothctl/runner.go
+++ b/internal/bluetoothctl/runner.go
@@ -1,0 +1,222 @@
+package bluetoothctl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+var geteuid = os.Geteuid
+
+type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// Runner executes bluetoothctl commands while handling privilege escalation when
+// necessary. The CLI relies on it to provide a thin wrapper around common
+// pairing and connection operations without forcing users to drop into the
+// interactive bluetoothctl shell.
+type Runner struct {
+	// Binary is the bluetoothctl executable path.
+	Binary string
+
+	// SudoPath is the sudo executable path used for privilege escalation.
+	SudoPath string
+
+	// UseSudo indicates whether commands should be executed through sudo.
+	UseSudo bool
+
+	useSudoSet bool
+	sudoSet    bool
+
+	run commandRunner
+}
+
+// RunnerOption customises Runner construction.
+type RunnerOption func(*Runner)
+
+// WithBinary sets the bluetoothctl binary path used by the runner.
+func WithBinary(path string) RunnerOption {
+	return func(r *Runner) {
+		r.Binary = path
+	}
+}
+
+// WithSudoPath overrides the sudo binary path used for escalation.
+func WithSudoPath(path string) RunnerOption {
+	return func(r *Runner) {
+		r.SudoPath = path
+		r.sudoSet = true
+	}
+}
+
+// WithUseSudo forces whether sudo should be used when invoking bluetoothctl.
+func WithUseSudo(use bool) RunnerOption {
+	return func(r *Runner) {
+		r.UseSudo = use
+		r.useSudoSet = true
+	}
+}
+
+// WithCommandRunner allows tests to replace the command execution primitive.
+func WithCommandRunner(run commandRunner) RunnerOption {
+	return func(r *Runner) {
+		r.run = run
+	}
+}
+
+// NewRunner constructs a Runner configured to execute bluetoothctl commands.
+// When no overrides are provided the runner automatically discovers the
+// bluetoothctl and sudo binaries on PATH. Non-root users default to executing
+// commands through sudo so operations that require elevated privileges succeed
+// without additional flags.
+func NewRunner(opts ...RunnerOption) (*Runner, error) {
+	r := &Runner{}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(r)
+		}
+	}
+
+	if r.Binary == "" {
+		path, err := exec.LookPath("bluetoothctl")
+		if err != nil {
+			return nil, fmt.Errorf("locate bluetoothctl: %w", err)
+		}
+		r.Binary = path
+	}
+
+	if r.SudoPath == "" && !r.sudoSet {
+		if path, err := exec.LookPath("sudo"); err == nil {
+			r.SudoPath = path
+		}
+	}
+
+	if !r.useSudoSet {
+		if geteuid() != 0 {
+			r.UseSudo = true
+		}
+	}
+
+	if r.UseSudo && r.SudoPath == "" {
+		return nil, errors.New("sudo binary not found while privilege escalation is required; run the command as root or install sudo")
+	}
+
+	if r.run == nil {
+		r.run = defaultCommandRunner
+	}
+
+	return r, nil
+}
+
+// Scan enables adapter discovery for the provided duration and returns the raw
+// bluetoothctl output. A zero or negative duration falls back to a 15 second
+// scan window.
+func (r *Runner) Scan(ctx context.Context, duration time.Duration) (string, error) {
+	if ctx == nil {
+		return "", errors.New("nil context passed to Scan")
+	}
+
+	if duration <= 0 {
+		duration = 15 * time.Second
+	}
+
+	secs := int(duration / time.Second)
+	if secs <= 0 {
+		secs = 1
+	}
+
+	args := []string{"--timeout", fmt.Sprintf("%d", secs), "scan", "on"}
+	output, err := r.exec(ctx, args...)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(output), nil
+}
+
+// Pair attempts to pair with the provided device address and returns the raw
+// bluetoothctl output.
+func (r *Runner) Pair(ctx context.Context, address string) (string, error) {
+	return r.simpleDeviceCommand(ctx, "pair", address)
+}
+
+// Connect attempts to connect to the provided device address and returns the
+// raw bluetoothctl output.
+func (r *Runner) Connect(ctx context.Context, address string) (string, error) {
+	return r.simpleDeviceCommand(ctx, "connect", address)
+}
+
+// Disconnect attempts to disconnect from the provided device address and
+// returns the raw bluetoothctl output.
+func (r *Runner) Disconnect(ctx context.Context, address string) (string, error) {
+	return r.simpleDeviceCommand(ctx, "disconnect", address)
+}
+
+func (r *Runner) simpleDeviceCommand(ctx context.Context, command, address string) (string, error) {
+	if ctx == nil {
+		return "", fmt.Errorf("nil context passed to %s", command)
+	}
+
+	addr := strings.TrimSpace(address)
+	if addr == "" {
+		return "", fmt.Errorf("device address required for %s", command)
+	}
+
+	args := []string{command, addr}
+	output, err := r.exec(ctx, args...)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(output), nil
+}
+
+func (r *Runner) exec(ctx context.Context, args ...string) (string, error) {
+	if ctx == nil {
+		return "", errors.New("nil context passed to exec")
+	}
+
+	var name string
+	var finalArgs []string
+	if r.UseSudo {
+		name = r.SudoPath
+		finalArgs = append([]string{r.Binary}, args...)
+	} else {
+		name = r.Binary
+		finalArgs = args
+	}
+
+	out, err := r.run(ctx, name, finalArgs...)
+	if err != nil {
+		return "", &CommandError{Args: args, Output: string(out), Err: err}
+	}
+
+	return string(out), nil
+}
+
+func defaultCommandRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	return cmd.CombinedOutput()
+}
+
+// CommandError captures failures when invoking bluetoothctl. Callers can inspect
+// the output to provide helpful user guidance.
+type CommandError struct {
+	Args   []string
+	Output string
+	Err    error
+}
+
+// Error implements error.
+func (e *CommandError) Error() string {
+	return fmt.Sprintf("bluetoothctl %s failed: %v", strings.Join(e.Args, " "), e.Err)
+}
+
+// Unwrap allows errors.Is / errors.As to inspect the root cause.
+func (e *CommandError) Unwrap() error {
+	return e.Err
+}

--- a/internal/bluetoothctl/runner_test.go
+++ b/internal/bluetoothctl/runner_test.go
@@ -103,7 +103,8 @@ func TestRunnerDisconnectNilContext(t *testing.T) {
 		t.Fatalf("NewRunner returned error: %v", err)
 	}
 
-	if _, err := runner.Disconnect(nil, "AA:BB"); err == nil {
+	var nilCtx context.Context
+	if _, err := runner.Disconnect(nilCtx, "AA:BB"); err == nil {
 		t.Fatalf("expected error for nil context")
 	}
 }

--- a/internal/bluetoothctl/runner_test.go
+++ b/internal/bluetoothctl/runner_test.go
@@ -1,0 +1,165 @@
+package bluetoothctl
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunnerScanUsesSudoWhenConfigured(t *testing.T) {
+	ctx := context.Background()
+	var gotName string
+	var gotArgs []string
+	runner, err := NewRunner(
+		WithBinary("bluetoothctl"),
+		WithSudoPath("sudo"),
+		WithUseSudo(true),
+		WithCommandRunner(func(_ context.Context, name string, args ...string) ([]byte, error) {
+			gotName = name
+			gotArgs = append([]string(nil), args...)
+			return []byte("scan output\n"), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRunner returned error: %v", err)
+	}
+
+	out, err := runner.Scan(ctx, 3*time.Second)
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+
+	if out != "scan output" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+
+	if gotName != "sudo" {
+		t.Fatalf("expected sudo to be used, got %q", gotName)
+	}
+
+	wantArgs := []string{"bluetoothctl", "--timeout", "3", "scan", "on"}
+	if len(gotArgs) != len(wantArgs) {
+		t.Fatalf("expected %d args, got %d", len(wantArgs), len(gotArgs))
+	}
+	for i := range wantArgs {
+		if gotArgs[i] != wantArgs[i] {
+			t.Fatalf("arg %d mismatch: want %q got %q", i, wantArgs[i], gotArgs[i])
+		}
+	}
+}
+
+func TestRunnerPairReturnsCommandErrorOnFailure(t *testing.T) {
+	runner, err := NewRunner(
+		WithBinary("bluetoothctl"),
+		WithUseSudo(false),
+		WithCommandRunner(func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if name != "bluetoothctl" {
+				t.Fatalf("expected bluetoothctl executable, got %q", name)
+			}
+			return []byte("Failed to pair"), errors.New("exit status 1")
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRunner returned error: %v", err)
+	}
+
+	_, err = runner.Pair(context.Background(), "AA:BB:CC:DD:EE:FF")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	cmdErr := &CommandError{}
+	if !errors.As(err, &cmdErr) {
+		t.Fatalf("expected CommandError, got %T", err)
+	}
+
+	if cmdErr.Output != "Failed to pair" {
+		t.Fatalf("unexpected output: %q", cmdErr.Output)
+	}
+}
+
+func TestRunnerConnectValidatesInput(t *testing.T) {
+	runner, err := NewRunner(
+		WithBinary("bluetoothctl"),
+		WithUseSudo(false),
+	)
+	if err != nil {
+		t.Fatalf("NewRunner returned error: %v", err)
+	}
+
+	if _, err := runner.Connect(context.Background(), ""); err == nil {
+		t.Fatalf("expected error for empty address")
+	}
+}
+
+func TestRunnerDisconnectNilContext(t *testing.T) {
+	runner, err := NewRunner(
+		WithBinary("bluetoothctl"),
+		WithUseSudo(false),
+	)
+	if err != nil {
+		t.Fatalf("NewRunner returned error: %v", err)
+	}
+
+	if _, err := runner.Disconnect(nil, "AA:BB"); err == nil {
+		t.Fatalf("expected error for nil context")
+	}
+}
+
+func TestRunnerScanDefaultsDuration(t *testing.T) {
+	ctx := context.Background()
+	var gotArgs []string
+	runner, err := NewRunner(
+		WithBinary("bluetoothctl"),
+		WithUseSudo(false),
+		WithCommandRunner(func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if name != "bluetoothctl" {
+				t.Fatalf("unexpected executable %q", name)
+			}
+			gotArgs = append([]string(nil), args...)
+			return []byte("ok"), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewRunner returned error: %v", err)
+	}
+
+	if _, err := runner.Scan(ctx, 0); err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+
+	if len(gotArgs) < 4 {
+		t.Fatalf("expected at least 4 arguments, got %v", gotArgs)
+	}
+
+	if gotArgs[0] != "--timeout" {
+		t.Fatalf("expected timeout flag, got %q", gotArgs[0])
+	}
+
+	if gotArgs[2] != "scan" || gotArgs[3] != "on" {
+		t.Fatalf("unexpected scan arguments: %v", gotArgs)
+	}
+}
+
+func TestNewRunnerRequiresSudoWhenNonRoot(t *testing.T) {
+	originalGeteuid := geteuid
+	defer func() { geteuid = originalGeteuid }()
+
+	geteuid = func() int {
+		return 1000
+	}
+
+	_, err := NewRunner(
+		WithBinary("bluetoothctl"),
+		WithSudoPath(""),
+	)
+	if err == nil {
+		t.Fatalf("expected error when sudo missing for non-root user")
+	}
+
+	if !strings.Contains(err.Error(), "sudo binary not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -79,7 +79,8 @@ func TestRunNilContext(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	if err := d.Run(nil); err == nil {
+	var nilCtx context.Context
+	if err := d.Run(nilCtx); err == nil {
 		t.Fatalf("expected error when context is nil")
 	}
 }


### PR DESCRIPTION
## Summary
- add a bluetoothctl runner with optional sudo escalation for device operations
- expose `peared devices` commands to scan, pair, connect, and disconnect hardware
- document the new workflow and cover the runner with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e347fc42c0832ba07ebf6d89f6cbf9