### PR TITLE
Document CLI adapter selection gaps and scan feedback

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,8 +33,9 @@ and run a minimal build/test loop without touching production systems.
 maintaining device connectivity across restarts or system hiccups.
 
 **Deliverables**
-- [x] Implement adapter discovery and selection across multiple controllers,
-      exposing the active adapter through the daemon API.
+- [ ] Implement adapter discovery and selection across multiple controllers,
+      exposing the active adapter through the daemon API and bluetoothctl
+      wrappers.
 - [ ] Surface radio block state (via BlueZ or rfkill) with clear error messaging
       and controlled unblocking, including audit logs of unblock attempts.
 - [ ] Provide reset workflows for bluetoothd (systemd), kernel modules, and
@@ -58,6 +59,8 @@ and surface state changes in a desktop environment.
 **Deliverables**
 - [ ] Deliver a CLI client for the daemon (connect, disconnect, scan, status,
       reset, forget) with contextual help output.
+- [ ] Surface progress feedback while device discovery is running so the CLI is
+      not silent during long scans.
 - [ ] Integrate desktop notifications via D-Bus (e.g., `notify-send`) with
       user-configurable verbosity levels.
 - [ ] Ship optional status bar outputs compatible with Waybar, Polybar, and


### PR DESCRIPTION
## Summary
- clarify README status to highlight manual adapter selection in the CLI
- document the silent scan behaviour and other current limitations for users
- update the roadmap to track adapter integration and scan progress feedback work

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e3549399b4832bbe4fd95b43c9c4a5